### PR TITLE
File generator tests fix

### DIFF
--- a/src/test/kotlin/Commons.kt
+++ b/src/test/kotlin/Commons.kt
@@ -1,4 +1,5 @@
 import org.maurezen.indexer.impl.read
+import java.io.File
 
 class Locator {}
 
@@ -15,3 +16,7 @@ fun printStrings(list: List<String>) {
 fun readTestFile() = read(filename)
 fun readTestFiles() = read(filenames)
 fun readTestBinaryFile() = read(binaryFilename)
+
+fun File.lines(): Int {
+    return read(absolutePath).size
+}


### PR DESCRIPTION
investigated and fixed the issues with the `MultithreadedTest.generateRandomDataFilesInADirIsDeterministicBasedOnSeed` that CI encountered

TLDR: flawed test setup

Failing runs:
https://github.com/maurezen/indexer/actions/runs/634529178
https://github.com/maurezen/indexer/actions/runs/635136776

After improving the reporting setup of the test, it turned out to be a bug in the test itself - under specific circumstances wrong files were compared for equality, which, naturally, failed.

Generated files now have an ordinal numerator as a part of their name, which allows us to deterministically, not heuristically, compare two file sequences