### PR TITLE
usability - optimized in-flight memory consumption

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,9 +127,10 @@ IndexBuilderCoroutines()
     .filter(ACCEPTS_EVERYTHING)
     .buildAsync().await()
 ```
-```
-.../dev/intellij-community-master/ indexed in 26704.4382 ms
-```
 
-While, again, a robust memory footprint measurement doesn't exist, a heap dump of a vm after indexing fits in ~260Mb. The indexing process itself, though, requires ~12G.
+|-Xmx|Time|
+|----|----|
+|12g |26.7s|
+|2g  |41.3s|
 
+While, again, a robust memory footprint measurement doesn't exist, a ready-to-query index of `intellij-community-master` has a memory footprint of ~230Mb. The indexing process itself, though, requires anywhere from 12Gb to as little as 1Gb, depending on indexing pipeline settings and trading throughput for memory footprint.

--- a/src/main/kotlin/org/maurezen/indexer/impl/coroutines/IndexBuilderCoroutines.kt
+++ b/src/main/kotlin/org/maurezen/indexer/impl/coroutines/IndexBuilderCoroutines.kt
@@ -1,15 +1,31 @@
 package org.maurezen.indexer.impl.coroutines
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import org.maurezen.indexer.Index
-import org.maurezen.indexer.impl.*
+import org.maurezen.indexer.impl.IndexEntryInternal
 import org.maurezen.indexer.impl.NGram.Companion.reverseNgramsForFile
+import org.maurezen.indexer.impl.mergeMapBitMap
 import org.maurezen.indexer.impl.multithreaded.IndexBuilderParallel
 import org.maurezen.indexer.impl.naive.DEFAULT_NGRAM_ARITY
 import org.maurezen.indexer.impl.naive.IndexNaive
 
+/**
+ * Coroutines-based parallel implementation of the indexer.
+ *
+ * For the time being uses a single scope both for readers and mergers; defaults to GlobalScope if none is passed.
+ *
+ * Readers & mergers allow for throughput<------>memory footprint tuning.
+ *
+ * Please see readme.md for throughput/footprint sample(s).
+ */
 class IndexBuilderCoroutines (
-    override val n: Int = DEFAULT_NGRAM_ARITY
+    override val n: Int = DEFAULT_NGRAM_ARITY,
+    private val scope: CoroutineScope = GlobalScope,
+    private val readers: Int = 256,
+    private val mergers: Int = 64,
+    private val filenameChannelCapacity: Int = 1024,
+    private val readerChannelCapacity: Int = 1024
 ) : IndexBuilderParallel(n) {
 
     @Volatile
@@ -20,11 +36,11 @@ class IndexBuilderCoroutines (
         if (updateNotInProgress) {
             var matches: HashMap<String, IndexEntryInternal>
 
-            currentUpdate = GlobalScope.async {
+            currentUpdate = scope.async {
 
                 val filenames = reader.explodeFileRoots(roots, filter)
-                val fileMaps = reverseNGramsForFilesCoroutine(this, filenames)
-                matches = coalesceReverseNgrams(fileMaps)
+
+                matches = reverseNGramsForFilesAndCoalesce(this, filenames)
 
                 val newIndex = IndexNaive(n, matches, filenames, reader)
 
@@ -42,11 +58,47 @@ class IndexBuilderCoroutines (
             .reduce { acc, entry -> acc.mergeMapBitMap(entry) }
             .orElse(hashMapOf())
 
-    private suspend fun reverseNGramsForFilesCoroutine(scope: CoroutineScope, filenames: List<String>): List<HashMap<String, IndexEntryInternal>> = run {
-        val jobs = filenames.mapIndexed { index, it ->
-            scope.async { reverseNgramsForFile(it, index, n, inspector, reader) }
+    private suspend fun reverseNGramsForFilesAndCoalesce(scope: CoroutineScope, filenames: List<String>): HashMap<String, IndexEntryInternal> = run {
+        val filenameChannel = Channel<Pair<Int, String>>(filenameChannelCapacity)
+        val readerChannel = Channel<HashMap<String, IndexEntryInternal>>(readerChannelCapacity)
+
+        val fileNameJob = scope.async {
+            filenames.mapIndexed{ index, it -> filenameChannel.send(Pair(index, it))}
         }
-        jobs.awaitAll()
+
+        val readerJobs = (1..readers).map {
+            scope.async {
+                for ((index, filename) in filenameChannel) {
+                    val fileIndex = reverseNgramsForFile(filename, index, n, inspector, reader)
+                    readerChannel.send(fileIndex)
+                }
+            }
+        }
+
+        val mergeJobs =
+            (1..mergers).map {
+                scope.async {
+
+                    var mergedIndex: HashMap<String, IndexEntryInternal> = hashMapOf()
+
+                    for (fileIndex in readerChannel) {
+                        if (mergedIndex.isEmpty()) {
+                            mergedIndex = fileIndex
+                        } else {
+                            mergedIndex.mergeMapBitMap(fileIndex)
+                        }
+                    }
+
+                    mergedIndex
+                }
+            }
+
+        fileNameJob.await()
+        filenameChannel.close()
+        readerJobs.awaitAll()
+        readerChannel.close()
+
+        return coalesceReverseNgrams(mergeJobs.awaitAll())
     }
 
 }

--- a/src/main/kotlin/org/maurezen/indexer/impl/naive/IndexNaive.kt
+++ b/src/main/kotlin/org/maurezen/indexer/impl/naive/IndexNaive.kt
@@ -86,9 +86,8 @@ class IndexNaive (
 
         val linesMax = 42
 
-        val entriesTotal = matches.values
-            .flatten()
-            .size
+        val entriesTotal = matches.values.map(IndexEntryInternal::cardinality)
+            .sum()
         val entriesPerNGramMax = matches.values
             .map(IndexEntryInternal::cardinality)
             .maxOrNull() ?: 0


### PR DESCRIPTION
optimized in-flight memory consumption by reducing the quatity of simultaneously maintained partially built indices from one per file to a configurable number. Provided configuration defaults do not degrade indexing intellij-community-master throughput on -Xmx12g and also allow to fit in -Xmx2g at ~half the throughput. Allowed user to supply own CoroutineScope (default to GlobalScope)